### PR TITLE
Add `tempel-define-template`

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -131,7 +131,7 @@ may be named with `tempel--name' or carry an evaluatable Lisp expression
 (defun tempel--expand-locations (locations)
   "Return the list of files sepecified by LOCATIONS.
 LOCATIONS is a list of files and directories."
-  (let (files)
+  (let ((files (if (listp locations) locations (list locations))))
     (dolist (file-or-dir locations)
       (if (file-directory-p file-or-dir)
 	  (dolist (file (directory-files file-or-dir t))
@@ -141,10 +141,7 @@ LOCATIONS is a list of files and directories."
 
 (defun tempel--load-templates ()
   "Return templates specified `tempel-template-locations'."
-  (let ((tempel-template-locations (if (listp tempel-template-locations)
-				       tempel-template-locations
-				     (list tempel-template-locations))))
-    (mapcan #'tempel--load (tempel--expand-locations tempel-template-locations))))
+  (mapcan #'tempel--load (tempel--expand-locations tempel-template-locations)))
 
 (defun tempel--annotate (templates width ellipsis sep name)
   "Annotate template NAME given the list of TEMPLATES.

--- a/tempel.el
+++ b/tempel.el
@@ -333,6 +333,8 @@ INIT is the optional initial input."
 			  tempel--modified mod))))
 	      (tempel--expand-locations tempel-template-locations)))
 
+;; Convenience function for returning a version of `tempel--templates' that's
+;; easier to loop through.
 (defun unpack-templates (templates)
   "Return a list of (mode name expansion)."
   (let (unpacked mode trigger expansion)
@@ -341,7 +343,7 @@ INIT is the optional initial input."
     (reverse unpacked)))
 
 (defun tempel--rebuild-templates (unpacked)
-  )
+  ())
 
 (defun tempel--templates ()
   "Return templates for current mode."
@@ -414,18 +416,21 @@ INIT is the optional initial input."
   ;; TODO disable only the topmost template?
   (while tempel--active (tempel--disable)))
 
+(defun tempel--same-template-p (template templates)
+  "Return non nil if a template has the same TRIGGER as something else in TEMPLATES."
+  (seq-find (lambda (template) (and (eq (car template)) (eq (car))))
+	    templates))
+
 ;; Before this we would overwrite the previous templates. We should actually
 ;; make sure that they are properly updated. In other words, the only values
 ;; that are overwritten are old values whose mode and trigger are identical to
 ;; that of a new value..
 (defun tempel-update-templates (new old)
   "Update the existing templates."
-  ;; Go through the old templates.
-  (let ((unique))
-    (dolist ()
-      (when (push )))
-    ())
-  (setq tempel--templates ()))
+  (let ((old tempel--templates)
+	(new (tempel--load-templates))
+	(non-duplicates (seq-filter (tempel--same-template-p new) old)))
+    (setq tempel--templates (append new non-duplicates))))
 
 ;;;###autoload
 (defun tempel-expand (&optional interactive)
@@ -486,17 +491,7 @@ If called interactively, select a template with `completing-read'."
 ;;;###autoload
 (defun tempel-define-template (trigger mode)
   "Define a template."
-  (push (cons mode (cons trigger body))))
-
-;;;###autoload
-;; (defmacro tempel-deftemplate (name args &rest body)
-;;   "Define a template.
-;; Name is the name of the template."
-;;   (let* ((trigger (car args))
-;; 	 (mode (cadr args))
-;; 	 (name ()))
-;;     `(progn (defun tempel-insert- ())
-;; 	    ())))
+  (push (cons mode (cons trigger body)) tempel--templates))
 
 (provide 'tempel)
 ;;; tempel.el ends here

--- a/tempel.el
+++ b/tempel.el
@@ -333,9 +333,15 @@ INIT is the optional initial input."
 			  tempel--modified mod))))
 	      (tempel--expand-locations tempel-template-locations)))
 
-(defun unpack-templates ()
+(defun unpack-templates (templates)
   "Return a list of (mode name expansion)."
-  (while ()))
+  (let (unpacked mode trigger expansion)
+    (while (and templates (symbolp (car templates)))
+      (push (list mode trigger expansion) unpacked))
+    (reverse unpacked)))
+
+(defun tempel--rebuild-templates (unpacked)
+  )
 
 (defun tempel--templates ()
   "Return templates for current mode."
@@ -415,7 +421,10 @@ INIT is the optional initial input."
 (defun tempel-update-templates (new old)
   "Update the existing templates."
   ;; Go through the old templates.
-  ()
+  (let ((unique))
+    (dolist ()
+      (when (push )))
+    ())
   (setq tempel--templates ()))
 
 ;;;###autoload

--- a/tempel.el
+++ b/tempel.el
@@ -460,5 +460,19 @@ If called interactively, select a template with `completing-read'."
        (defun ,cmd () (interactive) (tempel-insert ',name))
        (define-key ,(or map 'global-map) ,(kbd key) #',cmd))))
 
+;;;###autoload
+(defun tempel-define-template ()
+  (funcall `(lambda () (tempel-deftemplate ,name ,args))))
+
+;;;###autoload
+(defun tempel-deftemplate (name args &rest body)
+  "Define a template.
+Name is the name of the template."
+  (let* ((trigger (car args))
+	 (mode (cadr args))
+	 (name ()))
+    `(progn (defun tempel-insert- ())
+	    ())))
+
 (provide 'tempel)
 ;;; tempel.el ends here

--- a/tempel.el
+++ b/tempel.el
@@ -327,12 +327,19 @@ INIT is the optional initial input."
 	      (y-or-n-p "Save modified template files? ")))
     (mapc #'save-buffer modified)))
 
+(defun tempel--template-files-modified-p ()
+  "Return non-nil if any template files have been modified since loading."
+  (cl-find-if (lambda (file)
+		(let ((mod (file-attribute-modification-time (file-attributes file))))
+		  (unless (equal tempel--modified mod)
+		    (setq tempel--templates (tempel--load-templates)
+			  tempel--modified mod))))
+	      (tempel--expand-locations tempel-template-locations)))
+
 (defun tempel--templates ()
   "Return templates for current mode."
-  (let ((mod (file-attribute-modification-time (file-attributes tempel-file))))
-    (unless (equal tempel--modified mod)
-      (setq tempel--templates (tempel--load-templates tempel-template-locations)
-            tempel--modified mod)))
+  (when (tempel--template-files-modified-p)
+    (setq tempel--templates (tempel--load-templates)))
   (let (result (templates tempel--templates))
     (while (and templates (symbolp (car templates)))
       (when (derived-mode-p (car templates))

--- a/tempel.el
+++ b/tempel.el
@@ -333,6 +333,10 @@ INIT is the optional initial input."
 			  tempel--modified mod))))
 	      (tempel--expand-locations tempel-template-locations)))
 
+(defun unpack-templates ()
+  "Return a list of (mode name expansion)."
+  (while ()))
+
 (defun tempel--templates ()
   "Return templates for current mode."
   (when (tempel--template-files-modified-p)

--- a/tempel.el
+++ b/tempel.el
@@ -477,18 +477,17 @@ If called interactively, select a template with `completing-read'."
 ;;;###autoload
 (defun tempel-define-template (trigger mode)
   "Define a template."
-  (tempel-update-templates)
   (push (cons mode (cons trigger body))))
 
 ;;;###autoload
-(defun tempel-deftemplate (name args &rest body)
-  "Define a template.
-Name is the name of the template."
-  (let* ((trigger (car args))
-	 (mode (cadr args))
-	 (name ()))
-    `(progn (defun tempel-insert- ())
-	    ())))
+;; (defmacro tempel-deftemplate (name args &rest body)
+;;   "Define a template.
+;; Name is the name of the template."
+;;   (let* ((trigger (car args))
+;; 	 (mode (cadr args))
+;; 	 (name ()))
+;;     `(progn (defun tempel-insert- ())
+;; 	    ())))
 
 (provide 'tempel)
 ;;; tempel.el ends here

--- a/tempel.el
+++ b/tempel.el
@@ -404,6 +404,16 @@ INIT is the optional initial input."
   ;; TODO disable only the topmost template?
   (while tempel--active (tempel--disable)))
 
+;; Before this we would overwrite the previous templates. We should actually
+;; make sure that they are properly updated. In other words, the only values
+;; that are overwritten are old values whose mode and trigger are identical to
+;; that of a new value..
+(defun tempel-update-templates (new old)
+  "Update the existing templates."
+  ;; Go through the old templates.
+  ()
+  (setq tempel--templates ()))
+
 ;;;###autoload
 (defun tempel-expand (&optional interactive)
   "Complete template at point.
@@ -461,8 +471,10 @@ If called interactively, select a template with `completing-read'."
        (define-key ,(or map 'global-map) ,(kbd key) #',cmd))))
 
 ;;;###autoload
-(defun tempel-define-template ()
-  (funcall `(lambda () (tempel-deftemplate ,name ,args))))
+(defun tempel-define-template (trigger mode)
+  "Define a template."
+  (tempel-update-templates)
+  (push (cons mode (cons trigger body))))
 
 ;;;###autoload
 (defun tempel-deftemplate (name args &rest body)


### PR DESCRIPTION
This pull request is specifically for adding `tempel-define-template` and whatever changes are required to achieve this.

On the bare minimum, what `tempel-define-template` has to do (as I see it) is append a new element to `tempel--templates`. Its counterpart `tempo-define-template` does more--it creates an interactive function and a variable that corresponds to the template. But it is not clear to me how exactly that will be useful.

Something that needs to be changed for `tempel-define-template` is how templates are loaded currently. Right now, when you re-load template files, the templates are all overwritten. This is problematic for two reasons.

1. Loading does not usually work this way. Typically if you define, say, a function in a file and load it, then remove the function from the file, save the file and reload it, the function is still defined. Arguably, loading snippets should be the same way. Instead, we should append to the front of `tempel--templates` and additionally remove duplicate template definitions (by which I mean ones that have the same mode and name).

2. That would overwrite any templates defined by `tempel-define-template`.
