### PR TITLE
add tempel-maybe-expand

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -397,6 +397,21 @@ PROMPT is the optional prompt/default value."
   ;; TODO disable only the topmost template?
   (while tempel--active (tempel--disable)))
 
+(defun tempel--template-at-point-filter (cmd)
+  "If expandable template at point return CMD."
+  (when-let (templates (tempel--templates))
+    (let* ((region (tempel--region))
+           (bounds (or (and (not region) (bounds-of-thing-at-point 'symbol))
+                       (cons (point) (point))))
+           (str (buffer-substring (car bounds) (cdr bounds))))
+      (when (and (not tempel--active)
+                 (test-completion str templates))
+        cmd))))
+
+(defconst tempel-maybe-expand
+  '(menu-item "" tempel-expand :filter tempel--template-at-point-filter)
+  "Conditional key definition to potentially expand template.")
+
 ;;;###autoload
 (defun tempel-expand (&optional interactive)
   "Complete template at point.


### PR DESCRIPTION
Yasnippet has an interesting approach to potential snippet expansion
configuration `yas-maybe-expand`. They use a menu item and filter in
order to potentially expand a string at point. I've taken a shot at
doing this for Tempel. This would be useful for any tab-n-go
configurations and also provides a slightly different experience than
with `tempel-expand` since it does not start a capf process.