### PR TITLE
Feature suggestion: "eager" templates

### DIFF
--- a/README.org
+++ b/README.org
@@ -210,7 +210,8 @@ document the important ones here:
 - ~n~ Inserts a newline.
 - ~>~ Indents with ~indent-according-to-mode~.
 - ~r~ Inserts the current region.
-- ~r>~ The region, but indented.
+  If no region is active, quits the containing template when jumped to.
+- ~r>~ Acts like ~r~, but indent region.
 - ~n>~ Inserts a newline and indents.
 - ~&~ Insert newline if there is only whitespace between line start and point.
 - ~%~ Insert newline if there is only whitespace between point and line end.

--- a/README.org
+++ b/README.org
@@ -228,6 +228,7 @@ Furthermore Tempel supports syntax extensions:
 
 - ~(p FORM <NAME> <NONINS>)~ Like ~p~ described above, but ~FORM~ is evaluated.
 - ~(FORM ...)~ Other Lisp forms are evaluated. Named fields are lexically bound.
+- ~q~ Quits the containing template when jumped to.
 
 Use caution with templates which execute arbitrary code!
 

--- a/tempel.el
+++ b/tempel.el
@@ -331,6 +331,8 @@ Return the added field."
        (goto-char (cdr region))
        (when (eq (or (car-safe elt) elt) 'r>)
          (indent-region (car region) (cdr region) nil))))
+    ;; TEMPEL EXTENSION: Terminate template immediately
+    ('q (overlay-put (tempel--field st) 'tempel--terminate t))
     (_ (if-let (ret (run-hook-with-args-until-success 'tempel-user-elements elt))
            (tempel--element st region ret)
          ;; TEMPEL EXTENSION: Evaluate forms

--- a/tempel.el
+++ b/tempel.el
@@ -529,7 +529,12 @@ This is meant to be a source in `tempel-template-sources'."
   (cl-loop for i below (abs arg) do
            (if-let (next (tempel--find arg)) (goto-char next)
              (tempel-done)
-             (cl-return))))
+             (cl-return)))
+  ;; If the current field is marked as "terminating", disable its
+  ;; containing template right away.
+  (when-let* ((ov (tempel--field-at-point))
+              ((overlay-get ov 'tempel--terminate)))
+    (tempel--disable (overlay-get ov 'tempel--field))))
 
 (defun tempel-previous (arg)
   "Move ARG fields backward and quit at the beginning."

--- a/tempel.el
+++ b/tempel.el
@@ -194,9 +194,7 @@ REGION are the current region bouns"
 (defun tempel--range-modified (ov &rest _)
   "Range overlay OV modified."
   (when (and (not tempel--inhibit-hooks) (= (overlay-start ov) (overlay-end ov)))
-    (let ((st (overlay-get ov 'tempel--range)))
-      (setq tempel--active (cons st (delq st tempel--active)))
-      (tempel--disable))))
+    (tempel--disable (overlay-get ov 'tempel--range))))
 
 (defun tempel--field-modified (ov after beg end &optional _len)
   "Update field overlay OV.
@@ -361,7 +359,7 @@ If a field was added, return it."
     (eval (plist-get plist :pre) 'lexical)
     ;; TODO do we want to have the ability to reactivate snippets?
     (unless (eq buffer-undo-list t)
-      (push (list 'apply #'tempel--disable) buffer-undo-list))
+      (push '(apply tempel--disable) buffer-undo-list))
     (setf (alist-get 'tempel--active minor-mode-overriding-map-alist) tempel-map)
     (save-excursion
       ;; Split existing overlays, do not expand within existing field.

--- a/tempel.el
+++ b/tempel.el
@@ -555,9 +555,10 @@ This is meant to be a source in `tempel-template-sources'."
     (tempel-done)
     (delete-region beg end)))
 
-(defun tempel--disable ()
-  "Disable last template."
-  (when-let (st (pop tempel--active))
+(defun tempel--disable (&optional st)
+  "Disable template ST, or last template."
+  (when (setq st (or st (car tempel--active)))
+    (setq tempel--active (delq st tempel--active))
     (mapc #'delete-overlay (car st))
     (unless tempel--active
       (setq minor-mode-overriding-map-alist

--- a/tempel.el
+++ b/tempel.el
@@ -324,7 +324,10 @@ Return the added field."
     (`(l . ,lst) (dolist (e lst) (tempel--element st region e)))
     ((or 'p `(,(or 'p 'P) . ,rest)) (apply #'tempel--placeholder st rest))
     ((or 'r 'r> `(,(or 'r 'r>) . ,rest))
-     (if (not region) (apply #'tempel--placeholder st rest)
+     (if (not region)
+         (when-let (ov (apply #'tempel--placeholder st rest))
+           (unless rest
+             (overlay-put ov 'tempel--terminate t)))
        (goto-char (cdr region))
        (when (eq (or (car-safe elt) elt) 'r>)
          (indent-region (car region) (cdr region) nil))))

--- a/tempel.el
+++ b/tempel.el
@@ -268,7 +268,8 @@ If OV is alive, move it."
 (defun tempel--field (st &optional name init)
   "Add template field to ST.
 NAME is the optional field name.
-INIT is the optional initial input."
+INIT is the optional initial input.
+Return the added field."
   (let ((ov (make-overlay (point) (point))))
     (push ov (car st))
     (when name
@@ -288,10 +289,12 @@ INIT is the optional initial input."
       (overlay-put ov 'face 'tempel-default)
       (overlay-put ov 'tempel--default
                    (if (string-match-p ": \\'" init) 'end 'start)))
-    (tempel--synchronize-fields st ov)))
+    (tempel--synchronize-fields st ov)
+    ov))
 
 (defun tempel--form (st form)
-  "Add new template field evaluating FORM to ST."
+  "Add new template field evaluating FORM to ST.
+Return the added field."
   (let ((beg (point)))
     (condition-case nil
         (insert (eval form (cdr st)))
@@ -300,7 +303,8 @@ INIT is the optional initial input."
     (let ((ov (make-overlay beg (point) nil t)))
       (overlay-put ov 'face 'tempel-form)
       (overlay-put ov 'tempel--form form)
-      (push ov (car st)))))
+      (push ov (car st))
+      ov)))
 
 (defun tempel--element (st region elt)
   "Add template ELT to ST given the REGION."
@@ -332,7 +336,8 @@ INIT is the optional initial input."
 (defun tempel--placeholder (st &optional prompt name noinsert)
   "Handle placeholder element and add field with NAME to ST.
 If NOINSERT is non-nil do not insert a field, only bind the value to NAME.
-PROMPT is the optional prompt/default value."
+PROMPT is the optional prompt/default value.
+If a field was added, return it."
   (setq prompt
         (cond
          ((and (stringp prompt) noinsert) (read-string prompt))
@@ -340,7 +345,7 @@ PROMPT is the optional prompt/default value."
          ;; TEMPEL EXTENSION: Evaluate prompt
          (t (eval prompt (cdr st)))))
   (if noinsert
-      (setf (alist-get name (cdr st)) prompt)
+      (progn (setf (alist-get name (cdr st)) prompt) nil)
     (tempel--field st name prompt)))
 
 (defun tempel--insert (template region)

--- a/tempel.el
+++ b/tempel.el
@@ -327,12 +327,12 @@ Return the added field."
      (if (not region)
          (when-let (ov (apply #'tempel--placeholder st rest))
            (unless rest
-             (overlay-put ov 'tempel--terminate t)))
+             (overlay-put ov 'tempel--quit t)))
        (goto-char (cdr region))
        (when (eq (or (car-safe elt) elt) 'r>)
          (indent-region (car region) (cdr region) nil))))
     ;; TEMPEL EXTENSION: Terminate template immediately
-    ('q (overlay-put (tempel--field st) 'tempel--terminate t))
+    ('q (overlay-put (tempel--field st) 'tempel--quit t))
     (_ (if-let (ret (run-hook-with-args-until-success 'tempel-user-elements elt))
            (tempel--element st region ret)
          ;; TEMPEL EXTENSION: Evaluate forms
@@ -538,7 +538,7 @@ This is meant to be a source in `tempel-template-sources'."
   ;; If the current field is marked as "terminating", disable its
   ;; containing template right away.
   (when-let* ((ov (tempel--field-at-point))
-              ((overlay-get ov 'tempel--terminate)))
+              ((overlay-get ov 'tempel--quit)))
     (tempel--disable (overlay-get ov 'tempel--field))))
 
 (defun tempel-previous (arg)


### PR DESCRIPTION
Hi Daniel!

Thanks for this wonderful package; I use it every day 💛 

Here's a suggestion for a feature and an exemplary implementation that I ~hacked together~ successfully use locally. If you like the idea, I'm happy to polish this more and to include updates to the various doc-strings and the README according to your feedback.

In a gist, this allows for the definition of a template to be `(... :eager t)`, which means that it will auto-disable itself when you `tempel-next` to its last field.

Here are two example templates from your README that I think would work better if they'd be "eager":

```lisp
emacs-lisp-mode

(fun "(defun " p " (" p ")\n  \"" p "\"" n> r> ")")

org-mode

(src "#+begin_src " p n> r> n> "#+end_src")
```

As soon as I hit these templates' last placeholder (the function body, the block body), in my mind and workflow, I'm done dealing with the template: personally, I don't consider the content of the body as a field / a part of the template here even, but more as the place where I want the cursor to be when I'm done inserting the surrounding scaffolding.

I realize I could also manually `M-x tempel-done` as soon as I'm done with inserting and manipulating the template in the buffer, but for me at least, auto-disabling the template _when it makes sense to do so_ proofed really helpful to not break my flow of editing text and is much more aligned with the mental model of what I'm doing at that moment.

Let me know what you think. Thanks!