### PR TITLE
Add symbol support for tempel prompt syntax

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -346,6 +346,7 @@ If a field was added, return it."
         (cond
          ((and (stringp prompt) noinsert) (read-string prompt))
          ((stringp prompt) (propertize prompt 'tempel--default t))
+         ((symbolp prompt) (symbol-name prompt))
          ;; TEMPEL EXTENSION: Evaluate prompt
          (t (eval prompt (cdr st)))))
   (if noinsert


### PR DESCRIPTION
With this new introduction `(p "placeholder)` can be written as `(p 'placeholder)`