### PR TITLE
Add LSP completion workaround to the documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,6 +81,10 @@ The package is available on GNU ELPA and MELPA and can be installed with
     ;; either locally or globally. `expand-abbrev' is bound to C-x '.
     ;; (add-hook 'prog-mode-hook #'tempel-abbrev-mode)
     ;; (global-tempel-abbrev-mode)
+
+    ;; If using LSP we might need to run tempel-setup-capf after LSP completion
+    ;; setup to be able to expand before LSP completions.
+    ;; (advice-add 'lsp-completion-mode :after #'tempel-setup-capf)
   )
 
   ;; Optional: Use the Corfu completion UI


### PR DESCRIPTION
When LSP starts it overrides CAPF list and wipes our original tempel
setup. With the advice we override LSP once again.

I suspect there might be better ways to achieve this effect but this
works in my setup quite well so far.