### PR TITLE
Placeholder ordering

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -405,7 +405,10 @@ If a field was added, return it."
                do (let ((i (overlay-get ov 'tempel--field-index)))
                     (cond ((numberp i) nil)
                           (t (overlay-put ov 'tempel--field-index index))))))
-    (setf (cadr st) (seq-uniq (sort (cadr st) #'<)))
+    (setf (cadr st) (cl-loop for i in (sort (cadr st) #'<)
+                             when (not (member i ll))
+                             collect i into ll
+                             finally return ll))
     (tempel--rotate (cadr st) 1)))
 
 (defun tempel--insert (template region)
@@ -546,7 +549,7 @@ This is meant to be a source in `tempel-template-sources'."
   "Find next overlay in DIR."
   (let ((pt (point)) next stop)
     (dolist (st tempel--active next)
-      (let ((index (car (tempel--rotate (cadr st) (/ (* -1 dir) dir)))))
+      (let ((index (car (tempel--rotate (cadr st) (/ (- dir) (abs dir))))))
         (dolist (ov (car st))
           (unless (or (overlay-get ov 'tempel--form)
                       (not (overlay-get ov 'tempel--field-index))


### PR DESCRIPTION
These changes add the ability to specify the order in which placeholders should be visited.

Snippets now also accept the following forms:
```
((p INDEX))
((p INDEX) PROMPT <NAME> <NOINSERT>)
```

The INDEX decides, in which order placeholders are visited upon expansion.

If there are both indexed as well as non-indexed placeholders, snippet expansion will first visit ALL indexed placeholders and then non-indexed placeholders in order of occurence.

This idea came about because I wanted to use tempel as the snippet engine for eglot snippets. Because LSP returns snippets in TextMate format (as far as i can tell) I also created the following simple/naive conversion between TextMate and tempel formats, though I am not sure, this would be useful in the default tempel package.

```elisp
(defun tempel-textmate-convert (snippet)
  "Convert SNIPPET from TextMate to tempel format."
  (let*
      ((quoted (concat "(\"" snippet "\" > q)"))
       (final-pos (s-replace "$0" "\" > r> \"" quoted))
       (newlines (s-replace-regexp "\\w*\n\\w*" "\" > n> \"" final-pos))
       (placeholders (s-replace-regexp "\\$\\([0-9]+\\)" "\" ((p \\1) nil f\\1) \"" newlines))
       (placeholders-desc (s-replace-regexp "\\${\\([0-9]\\)+:\\(.*?\\)}" "\" ((p \\1) \"\\2\" f\\1) \"" placeholders)))
  (read placeholders-desc)))
```

I'm reasonably sure this change shouldn't change any previous behaviour, though I haven't tested this extensively yet.