### PR TITLE
Zap duplicate template

### DIFF
--- a/README.org
+++ b/README.org
@@ -181,7 +181,6 @@ access the template's named fields.
 
   (autoload ";;;###autoload")
   (pt "(point)")
-  (lambda "(lambda (" p ")" n> r> ")")
   (var "(defvar " p "\n  \"" p "\")")
   (local "(defvar-local " p "\n  \"" p "\")")
   (const "(defconst " p "\n  \"" p "\")")


### PR DESCRIPTION
The `lambda` template was contained twice in the examples: once for both `lisp-mode` and `emacs-lisp-mode`, and once for `emacs-lisp-mode` specifically.