### PR TITLE
Support tree-sitter's xx-ts-mode

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -487,6 +487,7 @@ This is meant to be a source in `tempel-template-sources'."
    (cl-loop
     for m in modes thereis
     (or (eq m #'fundamental-mode)
+       	(alist-get m major-mode-remap-alist)
         (derived-mode-p m)))
    (or (not (plist-member plist :when))
        (save-excursion


### PR DESCRIPTION
to enable tempel in xx-ts-mode need add corresponding mode into major-mode-remap-alis
eg: (add-to-list 'major-mode-remap-alist '(c-mode . c-ts-mode))