### PR TITLE
README: add hook to conf-mode, too

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,6 +85,7 @@ contributions.
                   (cons #'tempel-expand
                         completion-at-point-functions)))
 
+    (add-hook 'conf-mode-hook 'tempel-setup-capf)
     (add-hook 'prog-mode-hook 'tempel-setup-capf)
     (add-hook 'text-mode-hook 'tempel-setup-capf)
 


### PR DESCRIPTION
Because conf-mode is derived from neither prog- nor text-mode.