### PR TITLE
Only replace default field if not modifying a region

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -228,8 +228,9 @@ BEG and END are the boundaries of the modification."
     (let ((inhibit-modification-hooks nil)
           (tempel--inhibit-hooks t))
       (cond
-       ;; Erase default before modification if at beginning or end
-       ((and (not after) (overlay-get ov 'tempel--default)
+       ;; Erase default before modification if BEG and END are at the same
+       ;; point, and are at the beginning or end of the field.
+       ((and (not after) (overlay-get ov 'tempel--default) (eq beg end)
              (or (= beg (overlay-start ov)) (= end (overlay-end ov))))
         (delete-region (overlay-start ov) (overlay-end ov)))
        ;; Update field after modification


### PR DESCRIPTION
Sometimes, I have fields with defaults that I would like to make blank. I figured the best way to delete a field would be `tempel-kill` with `M-k`, but I noticed it seemed to be killing twice as much text as it should. Turns out, since the default field is being modified, it is deleted before the modification by `tempel--field-modified`, but the modification still occurs (in this case killing the region the default was previously in, deleting extra text).

In my opinion, if a region of text in the default field is being modified, the user likely wants to use part of the default in the final text, so it should not be removed. Therefore, I fixed my issue by adding a check that BEG and END of the region being modified are the same point, which fixes my issue with `M-k` and more generally fixes the unexpected behavior when modifying a default region, while maintaining the behavior of deleting the region when typing over it. Alternatively, if we still want the default field deleted when modifying a region, the or check on the current line 233 could be an exclusive or, which would handle my issue. 