### PR TITLE
Update org-mode template examples

### DIFF
--- a/README.org
+++ b/README.org
@@ -269,9 +269,9 @@ org-mode
 (latex "#+begin_export latex" n> r> n "#+end_export")
 (comment "#+begin_comment" n> r> n "#+end_comment")
 (verse "#+begin_verse" n> r> n "#+end_verse")
-(src "#+begin_src " q n> r> n "#+end_src")
+(src "#+begin_src " q n r n "#+end_src")
 (gnuplot "#+begin_src gnuplot :var data=" (p "table") " :file " (p "plot.png") n> r> n "#+end_src" :post (org-edit-src-code))
-(elisp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
+(elisp "#+begin_src emacs-lisp" n r n "#+end_src" :post (org-edit-src-code))
 (inlsrc "src_" p "{" q "}")
 (title "#+title: " p n "#+author: Daniel Mendler" n "#+language: en")
 


### PR DESCRIPTION
Updated the elisp and src examples so that they do not use `indent-according-to-tab`. When the header of the source block exists but the footer does not yet exist org-mode greedily looks for the next `#+end_src`, even if a `#+begin_src` precedes it. If it ends that `#+end_src` it then treats all text between tempel's freshly inserted src header and that existing footer as source doe and attempts to indent and possible format it accordingly. The results will vary by the source language, but for elisp it's indenting all text and then whenever it finds a `#` it prepends a `,`.

This change introduces no degradation to the template examples, but it does work with org-mode as is.