### PR TITLE
Replace by empty string when form evaluates to nil

### DIFF
--- a/tempel.el
+++ b/tempel.el
@@ -254,7 +254,7 @@ BEG and END are the boundaries of the modification."
         (save-excursion
           (goto-char (overlay-start ov))
           (let (x)
-            (setq x (or (and (setq x (overlay-get ov 'tempel--form)) (eval x (cdr st)))
+            (setq x (or (and (setq x (overlay-get ov 'tempel--form)) (or (eval x (cdr st)) ""))
                         (and (setq x (overlay-get ov 'tempel--name)) (alist-get x (cdr st)))))
             (when x (tempel--synchronize-replace (overlay-start ov) (overlay-end ov) ov x)))))
       ;; Move range overlay


### PR DESCRIPTION
This aligns the behavior of `tempel--synchronize-fields` with the one of `tempel--form`. Previously, if form updates returned nil, tempel did not update the form, even though during creation nil values become the empty string. Submitting separate from the other PR since I don't know if the current behaviour is intentional (I found it counter-intuitive).