### PR TITLE
Optional named field argument for custom user element hooks

### DIFF
--- a/README.org
+++ b/README.org
@@ -349,21 +349,41 @@ should take the second argument ~fields~, which refers to an alist that maps the
 field name to its value in the current template. For example,
 
 #+begin_src emacs-lisp
-(defun tempel-named-field (elt fields)
-    (when (eq (car-safe elt) 'nf)
-      (if-let (field-value (alist-get (cadr elt) fields))
-          field-value
-        (message "Undefined named field: %s" (cadr elt))
-        nil)))
-(add-to-list 'tempel-user-elements #'tempel-named-field)
+(defun tempel-include-from-file (elt fields)
+  (when (eq (car-safe elt) 'iff)
+    (if-let ((filename (cadr elt))
+             (content (with-temp-buffer
+                        (insert-file-contents filename)
+                        (buffer-string))))
+        (progn
+          (dolist (field fields)
+            (setq content (replace-regexp-in-string
+                           (format "%%(%s)s" (symbol-name (car field)))
+                           (cdr field)
+                           content)))
+          content)
+      (message "File %s not found" (cadr elt))
+      nil)))
+(add-to-list 'tempel-user-elements #'tempel-include-from-file)
 #+end_src
 
-Here, ~nf~ is an example of custom user element that uses a named field inside its
-hook function.
+adds the ~iff~ element which loads the content of a file given in the argument into a string, and replace all the occurrences of ~"%(field)s~ with the values of the named fields. If the content of the file named ~skel.org~ looks like this
+
+#+begin_src org
+,#+title: %(title)s
+,#+language: %(lang)s
+
+# local variables:
+# ispell-dictionary: "%(lang)s"
+# end:
+#+end_src
+
+then the following template will load the content after replacing ~%(title)s~ and ~%(lang)s~ with the corresponding named field values:
 
 #+begin_src emacs-lisp
-(p "foo: " foo t)
-(nf foo) ;; will render the value of the named field `foo'
+(org (p "title" title t)
+     (p "lang" lang t)
+     (iff "skel.org"))
 #+end_src
 
 * Adding template sources

--- a/README.org
+++ b/README.org
@@ -344,6 +344,28 @@ The following example templates uses the newly defined include element.
 (package (i header) r n n (i provide))
 #+end_src
 
+If a custom user element needs an access to named fields, the hook function
+should take the second argument ~fields~, which refers to an alist that maps the
+field name to its value in the current template. For example,
+
+#+begin_src emacs-lisp
+(defun tempel-named-field (elt fields)
+    (when (eq (car-safe elt) 'nf)
+      (if-let (field-value (alist-get (cadr elt) fields))
+          field-value
+        (message "Undefined named field: %s" (cadr elt))
+        nil)))
+(add-to-list 'tempel-user-elements #'tempel-named-field)
+#+end_src
+
+Here, ~nf~ is an example of custom user element that uses a named field inside its
+hook function.
+
+#+begin_src emacs-lisp
+(p "foo: " foo t)
+(nf foo) ;; will render the value of the named field `foo'
+#+end_src
+
 * Adding template sources
 
 Tempel offers a flexible mechanism for providing the templates, which are

--- a/tempel.el
+++ b/tempel.el
@@ -365,7 +365,13 @@ Return the added field."
          (indent-region (car region) (cdr region) nil))))
     ;; TEMPEL EXTENSION: Quit template immediately
     ('q (overlay-put (tempel--field st) 'tempel--enter #'tempel--done))
-    (_ (if-let ((ret (run-hook-with-args-until-success 'tempel-user-elements elt st)))
+    (_ (if-let ((ret (run-hook-wrapped 'tempel-user-elements
+                                       (lambda (hook elt fields)
+                                         (condition-case e
+                                             (funcall hook elt)
+                                           (wrong-number-of-arguments
+                                            (funcall hook elt fields))))
+                                       elt (cdr st))))
            (tempel--element st region ret)
          ;; TEMPEL EXTENSION: Evaluate forms
          (tempel--form st elt)))))

--- a/tempel.el
+++ b/tempel.el
@@ -365,7 +365,7 @@ Return the added field."
          (indent-region (car region) (cdr region) nil))))
     ;; TEMPEL EXTENSION: Quit template immediately
     ('q (overlay-put (tempel--field st) 'tempel--enter #'tempel--done))
-    (_ (if-let ((ret (run-hook-with-args-until-success 'tempel-user-elements elt)))
+    (_ (if-let ((ret (run-hook-with-args-until-success 'tempel-user-elements elt st)))
            (tempel--element st region ret)
          ;; TEMPEL EXTENSION: Evaluate forms
          (tempel--form st elt)))))


### PR DESCRIPTION
This PR 

  - updates the API for custom user element hook to accept an (optional) second argument `fields', an alist of field name-value pairs
  - adds a section in README describing the usage of the new API

See https://github.com/minad/tempel/discussions/152 for the wider context.