### PR TITLE
Add >>, the indent-region operator

### DIFF
--- a/README.org
+++ b/README.org
@@ -308,6 +308,8 @@ document the important ones here:
 - ~p~ Inserts an unnamed placeholder field.
 - ~n~ Inserts a newline.
 - ~>~ Indents with ~indent-according-to-mode~.
+- ~(>> ELEMENT ...)~ Takes a list of elements, inserts them and then indents
+  the entire result.
 - ~r~ Inserts the current region.
   If no region is active, quits the containing template when jumped to.
 - ~r>~ Acts like ~r~, but indent region.


### PR DESCRIPTION
This operator inserts all elements as normal, and then updates their indentation to match whatever indent-region would do. This helps get correctly-indented text in modes where unbalanced structure confuses the indentation engine.

The whole thing was discussed and proposed in https://github.com/minad/tempel/discussions/160#discussioncomment-11388289

The change isn't super straightforward, as we need a bit more logic to support placeholder fields moving:

* `tempel--inhibit-clearing-placeholders` is a new flag that allows the normal field-changing hooks to run, but prevents the default from changing, if indentation changed the field.
* A new branch on the `after` case of `tempel--field-modified` that moves the start of the overlay if text should be inserted before it (as indentation does).